### PR TITLE
Reload support

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,19 @@
 ---
 # handlers file for ansible-frr
-- name: restart frr
+- name: full restart frr
   service:
     name: frr
     state: restarted
     enabled: true
   become: true
+  when: frr_reload != true
+  listen: "restart frr"
+
+- name: reload frr
+  service:
+    name: frr
+    state: reloaded
+    enabled: true
+  become: true
+  when: frr_reload == true
+  listen: "restart frr"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -65,3 +65,9 @@
         ansible_distribution == "Ubuntu" and
         ansible_machine == 'armv7l'
 
+- name: install python frr tools
+  apt:
+    deb: "{{ frr_package_url }}/frr-pythontools_{{ frr_version }}-1.{{ ansible_distribution|lower }}{{ ansible_distribution_version }}+1_all.deb"
+    state: present
+  become: true
+  when: frr_reload == true

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -8,7 +8,9 @@ log {{ frr_logging }}
 {%   if frr_bgp is defined and frr_bgp != [] %}
 {%     for key, value in frr_bgp['asns'].iteritems() %}
 router bgp {{ key }}
+{%       if frr_router_id != [] %}
   bgp router-id {{ frr_router_id }}
+{%       endif %}
 {%       if value['log_neighbor_changes']|default(False) %}
   bgp log-neighbor-changes
 {%       endif %}


### PR DESCRIPTION
This modification is to install frr python tools to allow for reloading
of frr instead of having to restart whenever a configuration change is
made. I also changed a portion that would stop frr from reloading if the
frr_router_id was not set.