### PR TITLE
Keep connectivity after installing FRR on debian

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,7 +6,7 @@
     state: restarted
     enabled: true
   become: true
-  when: frr_reload != true
+  when: frr_reload != true or frrdownload.changed
   listen: "restart frr"
 
 - name: reload frr
@@ -15,5 +15,5 @@
     state: reloaded
     enabled: true
   become: true
-  when: frr_reload == true
+  when: frr_reload == true and not frrdownload.changed
   listen: "restart frr"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -81,10 +81,63 @@
     frr_debs: "{{ frr_debs }} + [ '{{ frr_package_deb }}' ]"
   when: frr_reload == true
 
-- name: Installing FRR {{ frr_version }}
-  apt: 
-    deb: "{{ item }}"
+- name: Install python-ipaddr
+  package:
+    name: python-ipaddr
     state: present
-    force: true
-  become: true
-  with_items: "{{ frr_debs }}"
+
+- name: Doing things for Ubuntu-18.04
+  block:
+    - name: Create our download directory
+      file:
+        path: /tmp/frr/{{ frr_version }}/
+        state: directory
+
+    - name: Download FRR package
+      get_url:
+        url: "{{ item }}"
+        dest: /tmp/frr/{{ frr_version }}/
+      with_items: "{{ frr_debs }}"
+      register: frrdownload
+
+    - name: Installing FRR {{ frr_version }} and netplan apply to fix connectivity
+      shell: |
+        dpkg --force-confnew -i /tmp/frr/{{ frr_version }}/frr*.deb
+        netplan apply
+      become: true
+      when: frrdownload.changed
+      notify: restart frr
+  when: ansible_lsb.release is version ('18.04', '>=')
+
+- name: Do things for not Ubuntu-18.04
+  block:
+    - name: Installing FRR {{ frr_version }}
+      apt:
+        deb: "{{ item }}"
+        state: present
+        force: true
+      become: true
+      with_items: "{{ frr_debs }}"
+      register: frrdownload
+  when: ansible_lsb.release is version ('18.04', '<')
+
+- name: Backup old /etc/frr/daemons.conf and /etc/default/frr
+  copy:
+    remote_src: True
+    src: "{{ item }}"
+    dest: "{{ item }}.bak"
+  notify: restart frr
+  when: frr_version > 6.0
+  with_items:
+    - /etc/frr/daemons.conf
+    - /etc/default/frr
+
+- name: Remove old /etc/frr/daemons.conf and /etc/default/frr
+  file:
+    path: "{{ item }}"
+    state: absent
+  notify: restart frr
+  when: frr_version > 6.0
+  with_items:
+    - /etc/frr/daemons.conf
+    - /etc/default/frr


### PR DESCRIPTION
When installing the FRR package, something happens to cause the default
routes to go away. In order to fix this, we simply need to run `netplan
apply`. But this needs to be chained off of the package install. So the
slightly goofy `shell` module for the package install and `netplan
apply` is a tad hacky, but provides a specific pattern we're attempting
to hit.

Signed-off-by: David Wahlstrom <david.wahlstrom@dreamhost.com>