### PR TITLE
Adding support to define timers connect for bgp neighbor

### DIFF
--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -68,6 +68,9 @@ router bgp {{ key }}
 {%           if values['next_hop_self']|default(False) %}
   neighbor {{ neighbor }} next-hop-self
 {%           endif %}
+{%           if values['timers_connect']|default(False) %}
+  neighbor {{ neighbor }} timers connect {{ values['timers_connect'] }}
+{%           endif %}
 {%           if values['v4_route_reflector_client']|default(False) or
                 values['v4_route_map']|default(False) %}
 !


### PR DESCRIPTION
Adding support for ansible/jinja to search the frr variables for bgp
`timers connect` option.

Signed-off-by: David Wahlstrom <david.wahlstrom@dreamhost.com>