### PR TITLE
Fixing check mode

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -99,6 +99,7 @@
         url: "{{ item }}"
         dest: /tmp/frr/{{ frr_version }}/
       with_items: "{{ frr_debs }}"
+      changed_when: false
       register: _frrdownload
 
     - name: Installing FRR {{ frr_version }} and netplan apply to fix connectivity

--- a/tasks/monitor.yml
+++ b/tasks/monitor.yml
@@ -21,6 +21,7 @@
     dest: "/opt/frr/monitoring/{{ item }}"
     mode: u=rwx,g=rwx,o=rwx
   become: true
+  when: not ansible_check_mode
   with_items:
     - bgp_neighbor_data.py
     - output_module.py


### PR DESCRIPTION
This fixes failures and 'changes' reported during the check mode. This
will allow for check mode to complete without throwing errors during a
play.