### PR TITLE
The upstream package repo changed. Need to fix for ubuntu18

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -41,7 +41,7 @@
 
 - name: debian | Installing FRR {{ frr_version }}
   apt:
-    deb: [ "{{ frr_package_url }}/frr_{{ frr_version }}{{frr_url_part|default('-1_')}}{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}{{frr_url_part_2|default('.1_')}}amd64.deb" ]
+    deb: "{{ frr_package_url }}/frr_{{ frr_version }}{{frr_url_part|default('-1_')}}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{frr_url_part_2|default('.1_')}}amd64.deb"
     state: present
   become: true
   when:


### PR DESCRIPTION
This changeset makes it so ubuntu18.04 can actually download the frr
package.

Signed-off-by: David Wahlstrom <david.wahlstrom@dreamhost.com>