### PR TITLE
Make sure FRR is started

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,6 +6,7 @@
     state: restarted
     enabled: true
   become: true
+  ignore_errors: true
   when: frr_reload != true or _frrdownload.changed
   listen: "restart frr"
 
@@ -15,5 +16,14 @@
     state: reloaded
     enabled: true
   become: true
+  ignore_errors: true
   when: frr_reload == true and not _frrdownload.changed
   listen: "restart frr"
+
+- name: start frr
+  service:
+    name: frr
+    state: started
+    enabled: true
+  become: true
+  listen: "start frr"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,7 @@
   become: true
   notify:
     - restart frr
+    - start frr
 
 - name: config | Configuring debian.conf
   template:
@@ -20,6 +21,7 @@
   become: true
   notify:
     - restart frr
+    - start frr
   when: ansible_os_family == "Debian"
 
 - name: config | Configuring zebra.conf
@@ -33,6 +35,7 @@
   register: _frr_zebra_configured
   notify:
     - restart frr
+    - start frr
 
 # We need to flush here in case interfaces are configured in zebra.conf
 - name: config | Flusing Handlers
@@ -54,3 +57,4 @@
   become: true
   notify:
     - restart frr
+    - start frr

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -108,7 +108,9 @@
         netplan apply
       become: true
       when: _frrdownload.changed
-      notify: restart frr
+      notify:
+        - restart frr
+        - start frr
   when: ansible_lsb.release is version ('18.04', '>=')
 
 - name: Do things for not Ubuntu-18.04
@@ -123,6 +125,12 @@
       register: _frrdownload
   when: ansible_lsb.release is version ('18.04', '<')
 
+- name: stat config
+  stat: path=/etc/default/frr
+  register: conf_stat
+  when:
+    - frr_version > 6.0
+
 - name: Backup old /etc/frr/daemons.conf and /etc/default/frr
   copy:
     remote_src: True
@@ -131,6 +139,7 @@
   ignore_errors: true
   when:
     - frr_version > 6.0
+    - conf_stat.stat.exists
   with_items:
     - /etc/frr/daemons.conf
     - /etc/default/frr
@@ -139,7 +148,9 @@
   file:
     path: "{{ item }}"
     state: absent
-  notify: restart frr
+  notify:
+    - restart frr
+    - start frr
   when:
     - frr_version > 6.0
   with_items:


### PR DESCRIPTION
Currently, there are times with reload that the service will lock up. If
this happens we will now make sure that the FRR instance is started at all
times. Also instead of ignoring failures we will check if the files
exist before moving them.