### PR TITLE
Family support for neighbors and networks

### DIFF
--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -97,8 +97,9 @@ router bgp {{ asn }}
 {%           if neighbor_data['v4_route_reflector_client']|default(False) or
                 neighbor_data['v4_route_map']|default(False) %}
 !
-  address-family ipv4 unicast
-{%             if neighbor_data['v4_route_reflector_client']|default(False) %}
+  address-family {{ neighbor_data['address_family']|default('ipv4 unicast') }}
+{%             if neighbor_data['v4_route_reflector_client']|default(False) or
+                  neighbor_data['route_reflector_client']|default(False) %}
     neighbor {{ neighbor }} route-reflector-client
 {%             endif %}
 {%             if neighbor_data['v4_route_map']|default(False) %}
@@ -106,28 +107,50 @@ router bgp {{ asn }}
     neighbor {{ neighbor }} route-map {{ _route_map }}
 {%               endfor %}
 {%             endif %}
+{%             if neighbor_data['route_map']|default(False) %}
+{%               for _route_map in neighbor_data['route_map'] %}
+    neighbor {{ neighbor }} route-map {{ _route_map }}
+{%               endfor %}
+{%             endif %}
   exit-address-family
+!
 !
 {%           endif %}
 {%         endfor %}
 {%       endif %}
-{%       if asn_data['networks'] is defined %}
+{%       if asn_data['networks'] is defined or 
+         if asn_data['redistribute'] is defined %}
   address-family ipv4 unicast
-{%         for network in asn_data['networks'] %}
+{%         if asn_data['networks'] is defined %}
+{%           for network in asn_data['networks'] %}
     network {{ network }}
-{%         endfor %}
-{%       endif %}
-{%       if asn_data['redistribute'] is defined %}
-{%         if asn_data['networks'] is not defined %}
-!
-  address-family ipv4 unicast
+{%           endfor %}
 {%         endif %}
-{%         for redist_protocol in asn_data['redistribute'] %}
+{%         if asn_data['redistribute'] is defined %}
+{%           for redist_protocol in asn_data['redistribute'] %}
     redistribute {{ redist_protocol }}
-{%         endfor %}
-{%       endif %}
-{%       if asn_data['networks'] is defined or asn_data['redistribute'] is defined %}
+{%           endfor %}
+{%         endif %}
   exit-address-family
+!
+!
+{%       endif %}
+{%       if asn_data['networks_v6'] is defined or 
+         if asn_data['redistribute_v6'] is defined %}
+  address-family ipv6 unicast
+{%         if asn_data['networks_v6'] is defined %}
+{%           for network in asn_data['networks_v6'] %}
+    network {{ network }}
+{%           endfor %}
+{%         endif %}
+{%         if asn_data['redistribute_v6'] is defined %}
+{%           for redist_protocol in asn_data['redistribute'] %}
+    redistribute {{ redist_protocol }}
+{%           endfor %}
+{%         endif %}
+  exit-address-family
+!
+!
 {%       endif %}
 {%       if frr_vnc_defaults|default(False) %}
   vnc defaults


### PR DESCRIPTION
This enables BGP family support for neighbors. This also enables the
ability to configure v6 networks for BGP family v6.