### PR TITLE
fixing peer group sorting

### DIFF
--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -83,7 +83,7 @@ router bgp {{ asn }}
 {%         endfor %}
 {%       endif %}
 {%       if asn_data['neighbors'] is defined %}
-{%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() %}
+{%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() | sort(reverse=True, attribute="1.is_peer_group") %}
 {%           if neighbor_data['v6only'] | default(False) %}
   neighbor {{ neighbor }} interface v6only
 {%           endif %}


### PR DESCRIPTION
This sorts neighbors based on `is_peer_group`, so that peer groups are always generated first in the config.  I have no idea how it actually is working, but it seems to work.