### PR TITLE
ensuring is_peer_group is set before accessed

### DIFF
--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -99,6 +99,9 @@ router bgp {{ asn }}
 {%       endif %}
 !
 {%       if asn_data['neighbors'] is defined %}
+{%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() %}
+{%           set x=neighbor_data.__setitem__('is_peer_group', neighbor_data['is_peer_group'] | default(False)) %}
+{%         endfor %}
 {%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() | sort(reverse=True, attribute="1.is_peer_group") %}
 {%           if neighbor_data['v6only'] | default(False) %}
   neighbor {{ neighbor }} interface v6only


### PR DESCRIPTION
Currently we're accessing is_peer_group before ensuring it's set.  This defaults it to false if not set, in a round-about way.  Please feel free to suggest a cleaner method if you know one!