### PR TITLE
Python3 support

### DIFF
--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -5,7 +5,7 @@ password {{ frr_password }}
 log {{ frr_logging }}
 !
 {% if frr_interfaces is defined and frr_interfaces != {} %}
-{%   for iface, iface_data in frr_interfaces.iteritems() %}
+{%   for iface, iface_data in frr_interfaces.items() %}
 interface {{ iface }}
 {%     if iface_data['description'] is defined %}
   description {{ iface_data['description'] }}
@@ -41,12 +41,12 @@ interface {{ iface }}
 {% endif %}
 !
 {% if frr_static is defined and frr_static != {} %}
-{%   for dest, next_hop in frr_static.iteritems() %}
+{%   for dest, next_hop in frr_static.items() %}
 ip route {{ dest }} {{ next_hop }}
 {%   endfor %}
 {% endif %}
 {% if frr_static_v6 is defined and frr_static_v6 != {} %}
-{%   for dest, next_hop in frr_static_v6.iteritems() %}
+{%   for dest, next_hop in frr_static_v6.items() %}
 ipv6 route {{ dest }} {{ next_hop }}
 {%   endfor %}
 {% endif %}
@@ -60,7 +60,7 @@ ipv6 forwarding
 !
 {% if frr_daemons['bgpd'] %}
 {%   if frr_bgp is defined and frr_bgp != {} %}
-{%     for asn, asn_data in frr_bgp['asns'].iteritems() %}
+{%     for asn, asn_data in frr_bgp['asns'].items() %}
 router bgp {{ asn }}
 {%       if frr_router_id is defined %}
   bgp router-id {{ frr_router_id }}
@@ -99,10 +99,10 @@ router bgp {{ asn }}
 {%       endif %}
 !
 {%       if asn_data['neighbors'] is defined %}
-{%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() %}
+{%         for neighbor, neighbor_data in asn_data['neighbors'].items() %}
 {%           set x=neighbor_data.__setitem__('is_peer_group', neighbor_data['is_peer_group'] | default(False)) %}
 {%         endfor %}
-{%         for neighbor, neighbor_data in asn_data['neighbors'].iteritems() | sort(reverse=True, attribute="1.is_peer_group") %}
+{%         for neighbor, neighbor_data in asn_data['neighbors'].items() | sort(reverse=True, attribute="1.is_peer_group") %}
 {%           if neighbor_data['v6only'] | default(False) %}
   neighbor {{ neighbor }} interface v6only
 {%           endif %}
@@ -227,7 +227,7 @@ router ospf
 {%       endif %}
 {%   if frr_ospf is defined and frr_ospf != {} %}
 {%     if frr_ospf['areas'] is defined %}
-{%       for area, area_data in frr_ospf['areas'].iteritems() %}
+{%       for area, area_data in frr_ospf['areas'].items() %}
 {%         for area_network in area_data['networks'] %}
   network {{ area_network }} area {{ area }}
 {%         endfor %}
@@ -261,8 +261,8 @@ router ospf
 {% endif %}
 !
 {% if frr_prefix_list is defined and frr_prefix_list != {} %}
-{%   for prefix_list_name, sequences in frr_prefix_list.iteritems() %}
-{%     for seq, seq_data in sequences.iteritems() %}
+{%   for prefix_list_name, sequences in frr_prefix_list.items() %}
+{%     for seq, seq_data in sequences.items() %}
 {%       if seq_data['prefix'] is defined %}
 {%         if seq_data['match'] is defined %}
 ip prefix-list {{ prefix_list_name }} seq {{ seq }} {{ seq_data['prefix'] }} {{ seq_data['match'] }}
@@ -275,8 +275,8 @@ ip prefix-list {{ prefix_list_name }} seq {{ seq }} {{ seq_data['prefix'] }}
 {% endif %}
 !
 {% if frr_prefix_list_v6 is defined and frr_prefix_list_v6 != {} %}
-{%   for prefix_list_name, sequences in frr_prefix_list_v6.iteritems() %}
-{%     for seq, seq_data in sequences.iteritems() %}
+{%   for prefix_list_name, sequences in frr_prefix_list_v6.items() %}
+{%     for seq, seq_data in sequences.items() %}
 {%       if seq_data['prefix'] is defined %}
 {%         if seq_data['match'] is defined %}
 ipv6 prefix-list {{ prefix_list_name }} seq {{ seq }} {{ seq_data['prefix'] }} {{ seq_data['match'] }}
@@ -289,8 +289,8 @@ ipv6 prefix-list {{ prefix_list_name }} seq {{ seq }} {{ seq_data['prefix'] }}
 {% endif %}
 !
 {% if frr_route_map is defined and frr_route_map != [] %}
-{%   for map_name, sequences in frr_route_map.iteritems() %}
-{%     for seq, seq_data in sequences.iteritems() %}
+{%   for map_name, sequences in frr_route_map.items() %}
+{%     for seq, seq_data in sequences.items() %}
 route-map {{ map_name }} {{ seq }}
 {%       if seq_data['interface'] is defined %}
   match interface {{ seq_data['interface'] }}

--- a/templates/etc/frr/zebra.conf.j2
+++ b/templates/etc/frr/zebra.conf.j2
@@ -5,7 +5,7 @@ password {{ frr_password }}
 log {{ frr_logging }}
 !
 {% if frr_interfaces is defined and frr_interfaces != {} %}
-{%   for iface, iface_data in frr_interfaces.iteritems() %}
+{%   for iface, iface_data in frr_interfaces.items() %}
 interface {{ iface }}
 {%     if iface_data['description'] is defined %}
   description {{ iface_data['description'] }}


### PR DESCRIPTION
This resolves the issue where iteritems() becomes items() in python3.
This is to support python3 fully as python 2.7 is EOL starting Jan
1, 2020.