### PR TITLE
Allow for APT REPO

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,6 +108,11 @@ frr_release_date: 2018010901
 # https://github.com/FRRouting/frr/releases
 frr_version: 6.0.2
 
+# Defines FRR apt repo
+# https://deb.frrouting.org/
+frr_apt_version: frr-stable
+frr_apt_repository: "deb https://deb.frrouting.org/frr {{ ansible_distribution_release }} {{ frr_apt_version }}"
+
 _frr_bgp_summary:
   stdout: ""
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,95 +1,31 @@
 ---
-- name: debian | Installing Pre-Reqs
-  apt:
-    name: ["iproute", "libc-ares2"]
+- name: Install FRR apt repo key
+  apt_key:
+    url: https://deb.frrouting.org/frr/keys.asc
     state: present
   become: true
-  when: >
-    (ansible_distribution == "Debian" and
-    ansible_distribution_version|int < 10) or
-    (ansible_distribution == "Ubuntu" and
-    ansible_distribution_version < "18.04")
+  register: add_repository_key
+  ignore_errors: true
 
-- name: debian | Installing Pre-Reqs Ubuntu 18+
-  apt:
-    name: ["iproute2", "libc-ares2", "libcap2", "libjson-c3", "logrotate"]
-    state: present
+- name: Ensure curl is present (on older systems without SNI).
+  package: name=curl state=present
   become: true
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_lsb.release is version ('18.04', '>=')
+  when: add_repository_key is failed
 
-- name: set url on frr between version 4 and 6.0.0
-  set_fact:
-    frr_url_part: "-1."
-    frr_url_part_2: "+1_"
-  when:
-    - frr_version > "4"
-    - frr_version <= "6.0"
-
-- name: set url on frr greater than version 6.0.0
-  set_fact:
-    frr_url_part: "-0."
-    frr_url_part_2: ".1_"
-    frr_url_part_3: ".1"
-  when:
-    - frr_version > "6.0"
-
-- name: debian | Installing FRR {{ frr_version }}
-  apt:
-    deb: "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}amd64.deb"
-    state: present
+- name: Add FRR apt key (alternative for older systems without SNI).
+  shell: |
+    set -o pipefail
+    curl -sSL https://deb.frrouting.org/frr/keys.asc | sudo apt-key add -
+  args:
+    warn: false
   become: true
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_machine == 'x86_64'
+  when: add_repository_key is failed
 
-- name: debian | Add FRR {{ frr_version }} (Arm)
-  set_fact:
-    frr_debs:
-      [
-        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}{{ frr_url_part_2|default('.1_') }}armhf.deb",
-      ]
+- name: Install FRR apt repo
+  apt_repository:
+    repo: "{{ frr_apt_repository }}"
     state: present
-  become: true
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_machine == 'armv7l'
-
-- name: Ubuntu | Add FRR {{ frr_version }}
-  set_fact:
-    frr_debs:
-      [
-        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}amd64.deb",
-      ]
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_machine == 'x86_64'
-
-- name: Ubuntu | Add FRR {{ frr_version }} (Arm)
-  set_fact:
-    frr_debs:
-      [
-        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}armhf.deb",
-      ]
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_machine == 'armv7l'
-
-- name: add python frr tools to install list
-  set_fact:
-    frr_package_deb: "{{ frr_package_url }}/frr-pythontools_{{ frr_version }}{{ frr_url_part }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_3 | default('+1') }}_all.deb"
-  when: frr_reload|bool
-
-- name: add python frr tools to install list
-  set_fact:
-    frr_debs: "{{ frr_debs }} + [ '{{ frr_package_deb }}' ]"
-  when: frr_reload|bool
-
-- name: Install python-ipaddr
-  package:
-    name: python-ipaddr
-    state: present
+    update_cache: true
   become: true
 
 - name: Remove Quagga
@@ -98,57 +34,19 @@
     state: absent
   become: true
 
-- name: Fetch FRR version
-  shell: "dpkg -l | grep frr | head -1 | awk '{print $3}' | sed 's/~.*//' | sed -r 's/-/./g' | cut -c1-5"
-  ignore_errors: true
-  changed_when: false
-  check_mode: no
-  register: _frr_version
-
-- name: Doing things for Ubuntu-18.04
-  block:
-    - name: Create our download directory
-      file:
-        path: /tmp/frr/{{ frr_version }}/
-        state: directory
-      changed_when: false
-
-    - name: Download FRR package
-      get_url:
-        url: "{{ item }}"
-        dest: /tmp/frr/{{ frr_version }}/
-      with_items: "{{ frr_debs }}"
-
-    - name: Installing FRR {{ frr_version }} and netplan apply to fix connectivity
-      shell: |
-        dpkg --force-confnew -i /tmp/frr/{{ frr_version }}/frr*.deb
-        netplan apply 2> /dev/null || { echo >&2 "no netplan installed";}
-      become: true
-      when: _frr_version.stdout != frr_version
-      notify:
-        - restart frr
-        - start frr
-  when: ansible_lsb.release is version ('18.04', '>=')
-
-- name: Do things for not Ubuntu-18.04
-  block:
-    - name: Installing FRR {{ frr_version }}
-      apt:
-        deb: "{{ item }}"
-        state: present
-        force: true
-      become: true
-      with_items: "{{ frr_debs }}"
-      register: _frrdownload
-      when: _frr_version.stdout != frr_version
-  when: ansible_lsb.release is version ('18.04', '<')
+- name: Install FRR
+  package:
+    name:
+      - frr
+      - python-ipaddr
+    state: latest
+  become: true
+  register: _frrdownload
 
 - name: stat config
   stat:
     path: /etc/default/frr
   register: conf_stat
-  when:
-    - frr_version > "6.0"
 
 - name: Backup old /etc/frr/daemons.conf and /etc/default/frr
   copy:
@@ -157,7 +55,6 @@
     dest: "{{ item }}.bak"
   ignore_errors: true
   when:
-    - frr_version > "6.0"
     - conf_stat.stat.exists
   with_items:
     - /etc/frr/daemons.conf

--- a/tasks/debian_legacy.yml
+++ b/tasks/debian_legacy.yml
@@ -1,0 +1,177 @@
+---
+- name: debian | Installing Pre-Reqs
+  apt:
+    name: ["iproute", "libc-ares2"]
+    state: present
+  become: true
+  when: >
+    (ansible_distribution == "Debian" and
+    ansible_distribution_version|int < 10) or
+    (ansible_distribution == "Ubuntu" and
+    ansible_distribution_version < "18.04")
+
+- name: debian | Installing Pre-Reqs Ubuntu 18+
+  apt:
+    name: ["iproute2", "libc-ares2", "libcap2", "libjson-c3", "logrotate"]
+    state: present
+  become: true
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_lsb.release is version ('18.04', '>=')
+
+- name: set url on frr between version 4 and 6.0.0
+  set_fact:
+    frr_url_part: "-1."
+    frr_url_part_2: "+1_"
+  when:
+    - frr_version > "4"
+    - frr_version <= "6.0"
+
+- name: set url on frr greater than version 6.0.0
+  set_fact:
+    frr_url_part: "-0."
+    frr_url_part_2: ".1_"
+    frr_url_part_3: ".1"
+  when:
+    - frr_version > "6.0"
+
+- name: debian | Installing FRR {{ frr_version }}
+  apt:
+    deb: "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}amd64.deb"
+    state: present
+  become: true
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_machine == 'x86_64'
+
+- name: debian | Add FRR {{ frr_version }} (Arm)
+  set_fact:
+    frr_debs:
+      [
+        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_major_version }}{{ frr_url_part_2|default('.1_') }}armhf.deb",
+      ]
+    state: present
+  become: true
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_machine == 'armv7l'
+
+- name: Ubuntu | Add FRR {{ frr_version }}
+  set_fact:
+    frr_debs:
+      [
+        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}amd64.deb",
+      ]
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == 'x86_64'
+
+- name: Ubuntu | Add FRR {{ frr_version }} (Arm)
+  set_fact:
+    frr_debs:
+      [
+        "{{ frr_package_url }}/frr_{{ frr_version }}{{ frr_url_part|default('-1_') }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_2|default('.1_') }}armhf.deb",
+      ]
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == 'armv7l'
+
+- name: add python frr tools to install list
+  set_fact:
+    frr_package_deb: "{{ frr_package_url }}/frr-pythontools_{{ frr_version }}{{ frr_url_part }}{{ ansible_distribution|lower }}{{ ansible_distribution_version }}{{ frr_url_part_3 | default('+1') }}_all.deb"
+  when: frr_reload|bool
+
+- name: add python frr tools to install list
+  set_fact:
+    frr_debs: "{{ frr_debs }} + [ '{{ frr_package_deb }}' ]"
+  when: frr_reload|bool
+
+- name: Install python-ipaddr
+  package:
+    name: python-ipaddr
+    state: present
+  become: true
+
+- name: Remove Quagga
+  package:
+    name: quagga
+    state: absent
+  become: true
+
+- name: Fetch FRR version
+  shell: "dpkg -l | grep frr | head -1 | awk '{print $3}' | sed 's/~.*//' | sed -r 's/-/./g' | cut -c1-5"
+  ignore_errors: true
+  changed_when: false
+  check_mode: no
+  register: _frr_version
+
+- name: Doing things for Ubuntu-18.04
+  block:
+    - name: Create our download directory
+      file:
+        path: /tmp/frr/{{ frr_version }}/
+        state: directory
+      changed_when: false
+
+    - name: Download FRR package
+      get_url:
+        url: "{{ item }}"
+        dest: /tmp/frr/{{ frr_version }}/
+      with_items: "{{ frr_debs }}"
+
+    - name: Installing FRR {{ frr_version }} and netplan apply to fix connectivity
+      shell: |
+        dpkg --force-confnew -i /tmp/frr/{{ frr_version }}/frr*.deb
+        netplan apply 2> /dev/null || { echo >&2 "no netplan installed";}
+      become: true
+      when: _frr_version.stdout != frr_version
+      notify:
+        - restart frr
+        - start frr
+  when: ansible_lsb.release is version ('18.04', '>=')
+
+- name: Do things for not Ubuntu-18.04
+  block:
+    - name: Installing FRR {{ frr_version }}
+      apt:
+        deb: "{{ item }}"
+        state: present
+        force: true
+      become: true
+      with_items: "{{ frr_debs }}"
+      register: _frrdownload
+      when: _frr_version.stdout != frr_version
+  when: ansible_lsb.release is version ('18.04', '<')
+
+- name: stat config
+  stat:
+    path: /etc/default/frr
+  register: conf_stat
+  when:
+    - frr_version > "6.0"
+
+- name: Backup old /etc/frr/daemons.conf and /etc/default/frr
+  copy:
+    remote_src: True
+    src: "{{ item }}"
+    dest: "{{ item }}.bak"
+  ignore_errors: true
+  when:
+    - frr_version > "6.0"
+    - conf_stat.stat.exists
+  with_items:
+    - /etc/frr/daemons.conf
+    - /etc/default/frr
+
+- name: Remove old /etc/frr/daemons.conf and /etc/default/frr
+  file:
+    path: "{{ item }}"
+    state: absent
+  notify:
+    - restart frr
+    - start frr
+  when:
+    - frr_version > "6.0"
+  with_items:
+    - /etc/frr/daemons.conf
+    - /etc/default/frr

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 # tasks file for ansible-frr
 - include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when:
+    - ansible_os_family == "Debian"
+    - frr_version >= "7.0"
+
+- include_tasks: debian_legacy.yml
+  when:
+    - ansible_os_family == "Debian"
+    - frr_version < "7.0"
 
 - include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
FRR has provided an apt repo for Debian based systems. This allows for
an easier install/upgrade path and the existing provisioning has moved
to debian_legacy where the new apt install has been created in
tasks/debian