### PR TITLE
Adding Focal Support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
         - trusty
         - xenial
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
   when:
     - ansible_os_family == "Debian"
     - frr_version >= "7.0"
+    - ansible_distribution_version > "20.04"
+
+- include_tasks: ubuntu.yml
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_version <= "20.04"
 
 - include_tasks: debian_legacy.yml
   when:

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,0 +1,10 @@
+---
+- name: Install FRR
+  package:
+    name:
+      - frr
+      - python-ipaddress
+      - frr-pythontools
+    state: latest
+  become: true
+  register: _frrdownload


### PR DESCRIPTION
Right now the Focal distribution has the most recent FRR. The FRR repos
do not support Focal currently, so to get this role to work we must use
the default repo for now.