### PR TITLE
Bionic should include debian.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,17 +4,17 @@
   when:
     - ansible_os_family == "Debian"
     - frr_version >= "7.0"
-    - ansible_distribution_version > "20.04"
-
-- include_tasks: ubuntu.yml
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_distribution_version <= "20.04"
-
+    - ansible_distribution_version < "20.04"
+    
 - include_tasks: debian_legacy.yml
   when:
     - ansible_os_family == "Debian"
     - frr_version < "7.0"
+    
+- include_tasks: ubuntu.yml
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_version >= "20.04"
 
 - include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
debian.yml includes the exact logic needed to deploy frr 7+ with bionic. There very well could be a better and more specific way to address this issue, but bionic does not like debian_legacy due to the specific version definition contained within.

Additionally - focal _or greater_, (not less than) should include ubuntu.yml