### PR TITLE
Allows for flushing handler conditionals

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -53,13 +53,9 @@
     - reload frr
     - start frr
 
-# We need to flush here in case interfaces are configured in zebra.conf
-- name: config | Flusing Handlers
-  meta: flush_handlers
-
-# We need to rediscover facts if interfaces are initially configured in zebra.conf
-- name: config | Rediscovering Facts # noqa 503
-  setup:
+## Importing a flush_handlers and rediscovery task only when zebra has changed
+- name: including flush_handlers and rediscovery
+  include_tasks: flush_rediscover.yml
   when: _frr_zebra_configured['changed']
 
 - name: config | Configuring FRR

--- a/tasks/flush_rediscover.yml
+++ b/tasks/flush_rediscover.yml
@@ -1,0 +1,8 @@
+---
+# We need to flush here in case interfaces are configured in zebra.conf
+- name: config | Flusing Handlers
+  meta: flush_handlers
+
+# We need to rediscover facts if interfaces are initially configured in zebra.conf
+- name: config | Rediscovering Facts # noqa 503
+  setup:


### PR DESCRIPTION
This is a workaround as you can't use conditionals on flushing handlers
but you can import tasks with conditionals and this imports the tasks of
flushing and rediscovering when zebra changes.