### PR TITLE
BGP Listen Range Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ frr_bgp:
         192.168.250.12:
           peer_group: group1
           description: far_away
+      listen_range:
+        192.168.250.0/24: group1
       networks:
         - "{{ frr_router_id }}/32"
         - "{{ hostvars[inventory_hostname]['ansible_enp0s8']['ipv4']['address'] }}/24"

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -182,10 +182,16 @@ router bgp {{ asn }}
 {%             endif %}
   exit-address-family
 !
-!
 {%           endif %}
 {%         endfor %}
 {%       endif %}
+!
+{%       if asn_data['listen_range'] is defined %}
+{%         for listen_range, listen_range_peer_group in asn_data['listen_range'].items() %}
+  bgp listen range {{ listen_range }} peer-group {{ listen_range_peer_group }}
+{%         endfor %}
+{%       endif %}
+!
 {%       if asn_data['networks'] | default(False) or
             asn_data['redistribute'] | default(False) %}
   address-family ipv4 unicast


### PR DESCRIPTION
This will enable the proper BGP listen range support under the bgp
instance. This is used in case you want to listen to a whole subnet in
order to peer with said subnet.