### PR TITLE
adding VRF support for interfaces and OSPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,18 +428,22 @@ ip link set dev ${IFACE} master ${VRF}
 
 
 ## VRF Definition
+
 ```yaml
 frr_vrf:
   - name: public
     router_id: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
   - name: mgmt
+  - name: dmz
     router_id: 192.168.100.100
 ```
-> NOTE: Device should have VRF's already configured.
+> NOTE: Device should have VRF's already configured:
 ```bash
 ip link add dev ${IFACE} type vrf table ${TABLE_ID}
 ip link set dev ${IFACE} up
 ```
+
+> **SUPPORT NOTE**: *router-id* definition for VRF is only supported in FRR-7.5.1 and higher!
 
 ## Upgrade/Downgrade
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
       - [Configuring STATIC routes](#configuring-static-routes)
   - [Interface Configuration](#interface-configuration)
     - [Interfaces](#interfaces)
-  - [VRF Definition](#vrf-definition)
   - [Upgrade/Downgrade](#upgradedowngrade)
   - [Quagga configuration](#quagga-configuration)
   - [License](#license)
@@ -379,7 +378,6 @@ frr_ospf_vrf_enabled:
           - 192.168.0.0/16
         type: nssa
 ```
-> NOTE: In order to run OSPF in custom VRF, see [VRF Definition](#vrf-definition)
 
 ### STATIC
 
@@ -426,24 +424,6 @@ frr_interfaces: # A dict. key = iface name, value = iface data
 ip link set dev ${IFACE} master ${VRF}
 ```
 
-
-## VRF Definition
-
-```yaml
-frr_vrf:
-  - name: public
-    router_id: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
-  - name: mgmt
-  - name: dmz
-    router_id: 192.168.100.100
-```
-> NOTE: Device should have VRF's already configured:
-```bash
-ip link add dev ${IFACE} type vrf table ${TABLE_ID}
-ip link set dev ${IFACE} up
-```
-
-> **SUPPORT NOTE**: *router-id* definition for VRF is only supported in FRR-7.5.1 and higher!
 
 ## Upgrade/Downgrade
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,37 @@ frr_ospf:
       dir: out
       protocol: connected
 ```
+#### VRF-aware OSPF
+
+Each key under ````frr_ospf_vrf_enabled```` represents VRF name:
+
+```yaml
+frr_ospf_vrf_enabled:
+  public:
+    redistribute:
+    - bgp
+    - connected
+    passive_interfaces:
+     - lo
+    log_adjacency_changes: true
+    areas:
+      1:
+        networks:
+          - "{{ hostvars[inventory_hostname]['ansible_ens3']['ipv4']['address'] }}/30"
+        auth: true
+  mgmt:
+    redistribute:
+      - kernel
+    areas:
+      0:
+        networks:
+          - 172.16.0.0/12
+      2:
+        networks:
+          - 192.168.0.0/16
+        type: nssa
+```
+> NOTE: Device should have VRF's already configured.
 
 ### STATIC
 
@@ -380,12 +411,22 @@ frr_interfaces: # A dict. key = iface name, value = iface data
     ipv6: # ipv6 can be a single value or list
       - 2001:0db8:85a3:8a2e::1/64
       - 2001:0db8:85a3:8a2e::2/64
+    vrf: management # put interface in 'management' VRF
     auth:
       id: 1
       key: supersecret
     other:
       - "no ipv6 nd suppress-ra"
       - "link-detect"
+```
+
+## VRF Definition
+```yaml
+frr_vrf:
+  - name: public
+    router_id: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
+  - name: mgmt
+    router_id: 192.168.100.100
 ```
 
 ## Upgrade/Downgrade

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@
     - [OSPF](#ospf)
       - [Enable OSPF](#enable-ospf)
       - [Configuring OSPF](#configuring-ospf)
+        - [VRF-aware OSPF](#vrf-aware-ospf)
     - [STATIC](#static)
       - [Configuring STATIC routes](#configuring-static-routes)
   - [Interface Configuration](#interface-configuration)
     - [Interfaces](#interfaces)
+  - [VRF Definition](#vrf-definition)
   - [Upgrade/Downgrade](#upgradedowngrade)
   - [Quagga configuration](#quagga-configuration)
   - [License](#license)
@@ -377,7 +379,7 @@ frr_ospf_vrf_enabled:
           - 192.168.0.0/16
         type: nssa
 ```
-> NOTE: Device should have VRF's already configured.
+> NOTE: In order to run OSPF in custom VRF, see [VRF Definition](#vrf-definition)
 
 ### STATIC
 
@@ -419,6 +421,11 @@ frr_interfaces: # A dict. key = iface name, value = iface data
       - "no ipv6 nd suppress-ra"
       - "link-detect"
 ```
+> NOTE: Device should have correct VRF assignment on each vrf-aware interface:
+```bash
+ip link set dev ${IFACE} master ${VRF}
+```
+
 
 ## VRF Definition
 ```yaml
@@ -427,6 +434,11 @@ frr_vrf:
     router_id: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
   - name: mgmt
     router_id: 192.168.100.100
+```
+> NOTE: Device should have VRF's already configured.
+```bash
+ip link add dev ${IFACE} type vrf table ${TABLE_ID}
+ip link set dev ${IFACE} up
 ```
 
 ## Upgrade/Downgrade

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -149,3 +149,6 @@ routing_type: frr
 
 # Global setting for "no bgp ebgp-requires-policy"
 frr_no_ebgp_requires_policy: false
+
+# reloads frr upon config changes
+frr_reload: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,7 @@
     enabled: true
   become: true
   listen: "reload frr"
+  when: frr_reload
 
 - name: start frr
   service:

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -10,7 +10,9 @@ log {{ frr_logging }}
 {% if frr_vrf is defined and frr_vrf != {} %}
 {%   for vrf in frr_vrf %}
 vrf {{ vrf.name }}
+{%     if vrf.router_id is defined %}
   ip router-id {{ vrf.router_id }}
+{%     endif %}
   exit-vrf
 !
 {%   endfor %}
@@ -257,6 +259,7 @@ router bgp {{ asn }}
 {% if frr_daemons['ospfd'] %}
 {%   if frr_ospf is defined and frr_ospf != {} %}
 {% set ospf_vrf_list = ["default"] %}
+{#   if only 'frr_ospf' section defined without 'frr_ospf_vrf_enabled', it will be configured for default VRF only #}
 {%     if frr_ospf_vrf_enabled is defined %}
 {%       for vrf in frr_ospf_vrf_enabled %}
 {{ ospf_vrf_list.append(vrf) or '!' }}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -9,7 +9,8 @@ log {{ frr_logging }}
 !
 {% if frr_vrf is defined and frr_vrf != {} %}
 {%   for vrf in frr_vrf %}
-vrf {{ vrf }}
+vrf {{ vrf.name }}
+  ip router-id {{ vrf.router_id }}
   exit-vrf
 !
 {%   endfor %}
@@ -254,11 +255,21 @@ router bgp {{ asn }}
 {% endif %}
 !
 {% if frr_daemons['ospfd'] %}
-router ospf
-{%       if frr_router_id is defined %}
+{%   if frr_ospf is defined and frr_ospf != {} %}
+{% set ospf_vrf_list = ["default"] %}
+{%     if frr_ospf_vrf_enabled is defined %}
+{%       for vrf in frr_ospf_vrf_enabled %}
+{{ ospf_vrf_list.append(vrf) or '!' }}
+{%       endfor  %}
+{%     endif %}
+{%       for vrf in ospf_vrf_list %}
+router ospf vrf {{ vrf }}
+{%     if vrf != "default" %}
+{% set frr_ospf = frr_ospf_vrf_enabled[vrf] %}
+{%     endif %}
+{%       if frr_router_id is defined and vrf == "default" %}
   router-id {{ frr_router_id }}
 {%       endif %}
-{%   if frr_ospf is defined and frr_ospf != {} %}
 {%     if frr_ospf['areas'] is defined %}
 {%       for area, area_data in frr_ospf['areas'].items() %}
 {%         for area_network in area_data['networks'] %}
@@ -290,48 +301,9 @@ router ospf
   distribute-list {{ acl.name }} {{ acl.dir }} {{ acl.protocol }}
 {%       endfor %}
 {%     endif %}
-{%   endif %}
-{% endif %}
 !
-{% if frr_daemons['ospfd'] and frr_ospf_vrf_enabled is defined %}
-{%       for instance in frr_ospf_vrf_enabled %}
-router ospf vrf {{ instance.vrf }}
-{%       if instance.frr_router_id is defined %}
-  router-id {{ instance.frr_router_id }}
-{%       endif %}
-{%     if instance['areas'] is defined %}
-{%       for area, area_data in instance['areas'].items() %}
-{%         for area_network in area_data['networks'] %}
-  network {{ area_network }} area {{ area }}
-{%         endfor %}
-{%         if area_data['auth'] is defined %}
-  area {{ area }} authentication message-digest
-{%         endif %}
-{%         if area_data['type'] is defined %}
-  area {{ area }} {{ area_data['type'] }}
-{%         endif %}
-{%       endfor %}
-{%     endif %}
-{%     if instance['log_adjacency_changes'] | default(False) %}
-  log-adjacency-changes
-{%     endif %}
-{%     if instance['passive_interfaces'] is defined %}
-{%       for passive_int in instance['passive_interfaces'] %}
-  passive-interface {{ passive_int }}
-{%       endfor %}
-{%     endif %}
-{%     if instance['redistribute'] is defined %}
-{%       for redist_protocol in instance['redistribute'] %}
-  redistribute {{ redist_protocol }}
-{%       endfor %}
-{%     endif %}
-{%     if instance['distribute_list'] is defined %}
-{%       for acl in instance['distribute_list'] %}
-  distribute-list {{ acl.name }} {{ acl.dir }} {{ acl.protocol }}
-{%       endfor %}
-{%     endif %}
-
-{%       endfor %}
+{%     endfor %}
+{%   endif %}
 {% endif %}
 !
 {% if frr_prefix_list is defined and frr_prefix_list != {} %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -10,7 +10,7 @@ log {{ frr_logging }}
 {% if frr_vrf is defined and frr_vrf != {} %}
 {%   for vrf in frr_vrf %}
 vrf {{ vrf.name }}
-{%     if vrf.router_id is defined %}
+{%     if vrf.router_id is defined and frr_version >= 7.5.1 %}
   ip router-id {{ vrf.router_id }}
 {%     endif %}
   exit-vrf

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -256,23 +256,28 @@ router bgp {{ asn }}
 {%   endif %}
 {% endif %}
 !
-{% if frr_daemons['ospfd'] %}
+{% if ( (frr_daemons['ospfd'] is defined) and
+        (frr_ospf is defined or frr_ospf_vrf_enabled is defined) ) %}
+{# define VRF list to iterate over it #}
+{%   set ospf_vrf_list = [] %}
+{#   when 'frr_ospf_vrf_enabled' is defined, 'ospf_vrf_list' is populated by defined vrf instances #}
+{#   when 'frr_ospf' is also defined, 'default' vrf is added to list #}
+{%   if frr_ospf_vrf_enabled is defined and frr_ospf_vrf_enabled != {} %}
+{%     for vrf in frr_ospf_vrf_enabled %}
+{{       ospf_vrf_list.append(vrf) or '!' }}
+{%     endfor  %}
+{%   endif %}
 {%   if frr_ospf is defined and frr_ospf != {} %}
-{% set ospf_vrf_list = ["default"] %}
-{#   if only 'frr_ospf' section defined without 'frr_ospf_vrf_enabled', it will be configured for default VRF only #}
-{%     if frr_ospf_vrf_enabled is defined %}
-{%       for vrf in frr_ospf_vrf_enabled %}
-{{ ospf_vrf_list.append(vrf) or '!' }}
-{%       endfor  %}
-{%     endif %}
-{%       for vrf in ospf_vrf_list %}
+{{     ospf_vrf_list.append("default") }}
+{%   endif %}
+{%     for vrf in ospf_vrf_list %}
 router ospf vrf {{ vrf }}
 {%     if vrf != "default" %}
-{% set frr_ospf = frr_ospf_vrf_enabled[vrf] %}
+{%       set frr_ospf = frr_ospf_vrf_enabled[vrf] %}
 {%     endif %}
-{%       if frr_router_id is defined and vrf == "default" %}
+{%     if frr_router_id is defined and vrf == "default" %}
   router-id {{ frr_router_id }}
-{%       endif %}
+{%     endif %}
 {%     if frr_ospf['areas'] is defined %}
 {%       for area, area_data in frr_ospf['areas'].items() %}
 {%         for area_network in area_data['networks'] %}
@@ -304,9 +309,7 @@ router ospf vrf {{ vrf }}
   distribute-list {{ acl.name }} {{ acl.dir }} {{ acl.protocol }}
 {%       endfor %}
 {%     endif %}
-!
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
 {% endif %}
 !
 {% if frr_prefix_list is defined and frr_prefix_list != {} %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -7,17 +7,6 @@ hostname {{ ansible_hostname }}
 password {{ frr_password }}
 log {{ frr_logging }}
 !
-{% if frr_vrf is defined and frr_vrf != {} %}
-{%   for vrf in frr_vrf %}
-vrf {{ vrf.name }}
-{%     if vrf.router_id is defined and frr_version >= 7.5.1 %}
-  ip router-id {{ vrf.router_id }}
-{%     endif %}
-  exit-vrf
-!
-{%   endfor %}
-{% endif %}
-!
 {% if frr_interfaces is defined and frr_interfaces != {} %}
 {%   for iface, iface_data in frr_interfaces.items() %}
 {%     if iface_data['vrf'] is defined %}

--- a/templates/etc/frr/frr.conf.j2
+++ b/templates/etc/frr/frr.conf.j2
@@ -7,9 +7,21 @@ hostname {{ ansible_hostname }}
 password {{ frr_password }}
 log {{ frr_logging }}
 !
+{% if frr_vrf is defined and frr_vrf != {} %}
+{%   for vrf in frr_vrf %}
+vrf {{ vrf }}
+  exit-vrf
+!
+{%   endfor %}
+{% endif %}
+!
 {% if frr_interfaces is defined and frr_interfaces != {} %}
 {%   for iface, iface_data in frr_interfaces.items() %}
+{%     if iface_data['vrf'] is defined %}
+interface {{ iface }} vrf {{ iface_data['vrf'] }}
+{%     else %}
 interface {{ iface }}
+{%     endif %}
 {%     if iface_data['description'] is defined %}
   description {{ iface_data['description'] }}
 {%     endif %}
@@ -279,6 +291,47 @@ router ospf
 {%       endfor %}
 {%     endif %}
 {%   endif %}
+{% endif %}
+!
+{% if frr_daemons['ospfd'] and frr_ospf_vrf_enabled is defined %}
+{%       for instance in frr_ospf_vrf_enabled %}
+router ospf vrf {{ instance.vrf }}
+{%       if instance.frr_router_id is defined %}
+  router-id {{ instance.frr_router_id }}
+{%       endif %}
+{%     if instance['areas'] is defined %}
+{%       for area, area_data in instance['areas'].items() %}
+{%         for area_network in area_data['networks'] %}
+  network {{ area_network }} area {{ area }}
+{%         endfor %}
+{%         if area_data['auth'] is defined %}
+  area {{ area }} authentication message-digest
+{%         endif %}
+{%         if area_data['type'] is defined %}
+  area {{ area }} {{ area_data['type'] }}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%     if instance['log_adjacency_changes'] | default(False) %}
+  log-adjacency-changes
+{%     endif %}
+{%     if instance['passive_interfaces'] is defined %}
+{%       for passive_int in instance['passive_interfaces'] %}
+  passive-interface {{ passive_int }}
+{%       endfor %}
+{%     endif %}
+{%     if instance['redistribute'] is defined %}
+{%       for redist_protocol in instance['redistribute'] %}
+  redistribute {{ redist_protocol }}
+{%       endfor %}
+{%     endif %}
+{%     if instance['distribute_list'] is defined %}
+{%       for acl in instance['distribute_list'] %}
+  distribute-list {{ acl.name }} {{ acl.dir }} {{ acl.protocol }}
+{%       endfor %}
+{%     endif %}
+
+{%       endfor %}
 {% endif %}
 !
 {% if frr_prefix_list is defined and frr_prefix_list != {} %}


### PR DESCRIPTION
This introduces VRF support for interfaces and ospf instances.

Default-vrf logic is preserved so there will be no impact on the default vrf-agnostic configurations.